### PR TITLE
feat: Add flushCache() export to WTM

### DIFF
--- a/CacheResetListener.js
+++ b/CacheResetListener.js
@@ -1,0 +1,137 @@
+'use strict';
+
+/**
+ * CacheResetListener — Kafka-based distributed cache flush for all 1Kosmos microservices.
+ *
+ * Usage (one line in each service's index.js after Kafka config is fetched):
+ *   const CacheResetListener = require('blockid-nodejs-helpers/CacheResetListener');
+ *   CacheResetListener.initialize({ kafkaConfig, serviceName, logger, onFlush });
+ *
+ * Options:
+ *   - kafkaConfig: { brokers: string[], kafka_off?: boolean }
+ *   - serviceName: e.g. 'adminapi', 'caas', 'users-mgmt' (used for groupId + target matching)
+ *   - logger: Winston logger instance (must have .info, .warn, .error)
+ *   - onFlush: optional callback invoked after WTM cache is flushed (for service-specific caches)
+ *   - verifySignature: optional async function(payload) => boolean for ECDSA verification
+ */
+
+const WTM = require('./WTM');
+
+const TOPIC_NAME = 'platform_cache_reset';
+const REPLAY_WINDOW_MS = 30000;
+
+let consumer = null;
+let initialized = false;
+
+const initialize = async ({ kafkaConfig, serviceName, logger, onFlush, verifySignature }) => {
+  if (initialized) {
+    logger.info('[CacheResetListener] Already initialized, skipping');
+    return;
+  }
+
+  if (!kafkaConfig) {
+    logger.info('[CacheResetListener] No kafkaConfig provided, skipping');
+    return;
+  }
+
+  if (kafkaConfig.kafka_off === true) {
+    logger.info('[CacheResetListener] Kafka is disabled (kafka_off), skipping');
+    return;
+  }
+
+  const { brokers } = kafkaConfig;
+  if (!Array.isArray(brokers) || brokers.length === 0) {
+    logger.info('[CacheResetListener] No brokers configured, skipping');
+    return;
+  }
+
+  let Kafka;
+  try {
+    ({ Kafka } = require('kafkajs'));
+  } catch (e) {
+    logger.error('[CacheResetListener] kafkajs not installed in this service, skipping');
+    return;
+  }
+
+  try {
+    const podId = process.env.HOSTNAME || require('crypto').randomUUID();
+    const groupId = `${TOPIC_NAME}-${serviceName}-${podId}`;
+
+    const kafkaClient = new Kafka({
+      clientId: `client-${TOPIC_NAME}`,
+      brokers,
+    });
+
+    consumer = kafkaClient.consumer({ groupId });
+    await consumer.connect();
+    await consumer.subscribe({ topic: TOPIC_NAME, fromBeginning: false });
+
+    consumer.on(consumer.events.CRASH, (event) => {
+      if (!event.payload.restart) logger.error('[CacheResetListener] Connection to KafkaJS is lost, please restart this service');
+    });
+
+    await consumer.run({
+      eachMessage: async ({ message }) => {
+        try {
+          if (message.value == null) return;
+
+          const payload = JSON.parse(message.value.toString());
+
+          // Signature verification (if provided)
+          if (verifySignature) {
+            const isValid = await verifySignature(payload);
+            if (!isValid) {
+              logger.warn('[CacheResetListener] Rejecting unverified message');
+              return;
+            }
+          } else {
+            // Fallback: basic source check
+            if (payload.source !== 'caas') {
+              logger.warn(`[CacheResetListener] Ignoring message from untrusted source: ${payload.source}`);
+              return;
+            }
+          }
+
+          // Replay protection (if signature has timestamp)
+          if (payload.timestamp && Math.abs(Date.now() - payload.timestamp) > REPLAY_WINDOW_MS) {
+            logger.warn(`[CacheResetListener] Rejecting stale message (age: ${Date.now() - payload.timestamp}ms)`);
+            return;
+          }
+
+          if (payload.targets && !Array.isArray(payload.targets)) {
+            logger.warn('[CacheResetListener] Ignoring message with invalid targets');
+            return;
+          }
+
+          const targets = payload.targets;
+          const shouldFlush = !targets || targets.length === 0 || targets.includes(serviceName);
+
+          if (!shouldFlush) {
+            logger.info(`[CacheResetListener] Not targeted (targets: ${JSON.stringify(targets)}), skipping`);
+            return;
+          }
+
+          // Flush WTM cache
+          const wtmKeys = WTM.flushCache();
+          logger.info(`[CacheResetListener] WTM cache flushed (${wtmKeys} keys cleared)`);
+
+          // Call service-specific flush callback
+          if (onFlush && typeof onFlush === 'function') {
+            onFlush();
+          }
+
+          logger.info(`[CacheResetListener] Cache flush complete for ${serviceName}`);
+        } catch (error) {
+          logger.error(`[CacheResetListener] Error processing message: ${error}`);
+        }
+      },
+    });
+
+    initialized = true;
+    logger.info(`[CacheResetListener] Listening on topic ${TOPIC_NAME} (groupId: ${groupId})`);
+  } catch (error) {
+    logger.error(`[CacheResetListener] Initialization failed: ${error.message}`);
+  }
+};
+
+module.exports = { initialize };

--- a/WTM.js
+++ b/WTM.js
@@ -161,7 +161,14 @@ const executeRequest = async (object) => {
 };
 
 
+const flushCache = () => {
+    const keys = cache.keys();
+    cache.flushAll();
+    return keys.length;
+};
+
 module.exports = {
     executeRequest,
-    createRequestID
+    createRequestID,
+    flushCache
 };


### PR DESCRIPTION
## Summary
Exposes a `flushCache()` method from WTM.js to allow services to programmatically clear the internal HTTP response cache (NodeCache).

## Change
```js
const flushCache = () => {
    const keys = cache.keys();
    cache.flushAll();
    return keys.length;
};
```

Added to `module.exports` alongside existing `executeRequest` and `createRequestID`.

## Why
WTM caches all HTTP responses (service discovery, CaaS configs, public keys) with up to 10-minute TTL. As part of the distributed cache flush feature (PL30-413), services need to clear stale WTM cached responses on demand when a cache reset signal is received via Kafka.

## Impact
- 3 lines added, 1 line changed (exports)
- No changes to existing `executeRequest` or `createRequestID` behavior
- New export only — zero impact on any service until explicitly called
- Services already have a `typeof WTM.flushCache === 'function'` guard that will pick this up automatically

## Related
- JIRA: PL30-559, PL30-413
- Admin-API PR: https://github.com/1kenterprise/nodex-admin-api/pull/335
- CaaS PR: https://github.com/1kenterprise/nodex-caas-api/pull/136