### PR TITLE
PL30-413: Distributed cache flush — CacheRegistry + CacheResetListener

### DIFF
--- a/CacheRegistry.js
+++ b/CacheRegistry.js
@@ -46,7 +46,7 @@ const flushAll = () => {
 
   allCaches.forEach((cache) => {
     try {
-      totalKeys += (cache.getStats && cache.getStats().keys) || cache.keys().length;
+      totalKeys += (typeof cache.getStats === 'function' ? cache.getStats().keys : cache.keys().length) ?? 0;
       cache.flushAll();
     } catch (e) { /* skip — cache instance may be in a bad state */ }
   });

--- a/CacheRegistry.js
+++ b/CacheRegistry.js
@@ -1,0 +1,48 @@
+'use strict';
+
+/**
+ * CacheRegistry — Auto-captures all NodeCache instances for centralized flush.
+ *
+ * MUST be required at the very top of index.js (before any other require that creates NodeCache):
+ *   require('blockid-nodejs-helpers/CacheRegistry');
+ *
+ * After this, any `new NodeCache()` anywhere in the service is auto-registered.
+ * When flushAll() is called, every NodeCache instance + WTM cache is cleared.
+ */
+
+const NodeCache = require('node-cache');
+
+const allCaches = [];
+
+// Patch NodeCache constructor to auto-register every instance
+const _originalInit = NodeCache.prototype.init;
+NodeCache.prototype.init = function (...args) {
+  allCaches.push(this);
+  return _originalInit.apply(this, args);
+};
+
+/**
+ * Flushes ALL NodeCache instances in the process + WTM HTTP response cache.
+ * @returns {{ nodeCaches: number, wtmKeys: number }}
+ */
+const flushAll = () => {
+  let totalKeys = 0;
+  allCaches.forEach((c) => {
+    try {
+      totalKeys += c.keys().length;
+      c.flushAll();
+    } catch (e) { /* ignore */ }
+  });
+
+  let wtmKeys = 0;
+  try {
+    const WTM = require('./WTM');
+    if (typeof WTM.flushCache === 'function') {
+      wtmKeys = WTM.flushCache();
+    }
+  } catch (e) { /* ignore */ }
+
+  return { nodeCaches: allCaches.length, totalKeys, wtmKeys };
+};
+
+module.exports = { flushAll, allCaches };

--- a/CacheRegistry.js
+++ b/CacheRegistry.js
@@ -21,9 +21,15 @@ NodeCache.prototype.init = function (...args) {
   return _originalInit.apply(this, args);
 };
 
+// Resolve WTM once at module load (avoids repeated require lookup on every flush)
+let WTM = null;
+try {
+  WTM = require('./WTM');
+} catch (e) { /* WTM not available — skip */ }
+
 /**
  * Flushes ALL NodeCache instances in the process + WTM HTTP response cache.
- * @returns {{ nodeCaches: number, wtmKeys: number }}
+ * @returns {{ nodeCaches: number, totalKeys: number, wtmKeys: number }}
  */
 const flushAll = () => {
   let totalKeys = 0;
@@ -31,16 +37,15 @@ const flushAll = () => {
     try {
       totalKeys += c.keys().length;
       c.flushAll();
-    } catch (e) { /* ignore */ }
+    } catch (e) { /* ignore dead cache reference */ }
   });
 
   let wtmKeys = 0;
-  try {
-    const WTM = require('./WTM');
-    if (typeof WTM.flushCache === 'function') {
+  if (WTM && typeof WTM.flushCache === 'function') {
+    try {
       wtmKeys = WTM.flushCache();
-    }
-  } catch (e) { /* ignore */ }
+    } catch (e) { /* ignore */ }
+  }
 
   return { nodeCaches: allCaches.length, totalKeys, wtmKeys };
 };

--- a/CacheRegistry.js
+++ b/CacheRegistry.js
@@ -13,45 +13,31 @@
  *     require('blockid-nodejs-helpers/CacheRegistry');
  *
  *   That's it. All caches created after this line are automatically tracked.
- *   Safe no-op if node-cache is not installed.
  */
 
+const RealNodeCache = require('node-cache');
 const allCaches = [];
 
-// Patch node-cache if available — safe no-op if not installed
-try {
-  const RealNodeCache = require('node-cache');
-
-  function TrackedNodeCache(...args) {
-    const instance = new RealNodeCache(...args);
-    allCaches.push(instance);
-    return instance;
-  }
-  TrackedNodeCache.prototype = RealNodeCache.prototype;
-
-  const nodeCacheEntry = require.cache[require.resolve('node-cache')];
-  if (nodeCacheEntry) {
-    nodeCacheEntry.exports = TrackedNodeCache;
-  }
-} catch (e) {
-  if (e.code !== 'MODULE_NOT_FOUND') throw e;
-  // node-cache not installed — flushAll() will be a no-op
+function TrackedNodeCache(...args) {
+  const instance = new RealNodeCache(...args);
+  allCaches.push(instance);
+  return instance;
 }
+TrackedNodeCache.prototype = RealNodeCache.prototype;
+
+require.cache[require.resolve('node-cache')].exports = TrackedNodeCache;
 
 /**
  * Clears ALL cached data across the entire service.
- * Called by CacheResetListener when a flush signal is received from Kafka.
  */
 const flushAll = () => {
   let totalKeys = 0;
-
   allCaches.forEach((cache) => {
     try {
-      totalKeys += (typeof cache.getStats === 'function' ? cache.getStats().keys : cache.keys().length) ?? 0;
+      totalKeys += cache.keys().length;
       cache.flushAll();
-    } catch (e) { /* skip — cache instance may be in a bad state */ }
+    } catch (e) { /* skip */ }
   });
-
   return { nodeCaches: allCaches.length, totalKeys };
 };
 

--- a/CacheRegistry.js
+++ b/CacheRegistry.js
@@ -1,62 +1,54 @@
 'use strict';
 
 /**
- * CacheRegistry — Auto-captures all NodeCache instances for centralized flush.
+ * CacheRegistry — Tracks all NodeCache instances for centralized flush.
  *
- * MUST be required at the very top of index.js (before any other require that creates NodeCache):
- *   require('blockid-nodejs-helpers/CacheRegistry');
+ * HOW IT WORKS:
+ *   1. This file replaces the 'node-cache' module with a wrapper.
+ *   2. Every time anyone does `new NodeCache()`, the instance is saved in a list.
+ *   3. When `flushAll()` is called, every saved instance is cleared.
  *
- * After this, any `new NodeCache()` anywhere in the service is auto-registered.
- * When flushAll() is called, every NodeCache instance + WTM cache is cleared.
+ * USAGE:
+ *   Add this as the FIRST require in your service's entry point (index.js / server.js):
+ *     require('blockid-nodejs-helpers/CacheRegistry');
+ *
+ *   That's it. All caches created after this line are automatically tracked.
  */
 
-const OriginalNodeCache = require('node-cache');
+// Step 1: Save the real NodeCache constructor
+const RealNodeCache = require('node-cache');
 
+// Step 2: Keep a list of all cache instances
 const allCaches = [];
 
-// Replace node-cache module export with a wrapper that captures every instance.
-// node-cache v5.x does NOT have a `.init()` prototype method, so patching the
-// constructor via the require cache is the only reliable interception point.
-function PatchedNodeCache(...args) {
-  const instance = new OriginalNodeCache(...args);
+// Step 3: Create a wrapper that saves each new instance to the list
+function TrackedNodeCache(...args) {
+  const instance = new RealNodeCache(...args);
   allCaches.push(instance);
   return instance;
 }
+TrackedNodeCache.prototype = RealNodeCache.prototype;
 
-// Preserve prototype chain so instanceof checks still work
-PatchedNodeCache.prototype = OriginalNodeCache.prototype;
-PatchedNodeCache.prototype.constructor = PatchedNodeCache;
-
-// Replace in Node's require cache so all subsequent `require('node-cache')` get the patched version
-require.cache[require.resolve('node-cache')].exports = PatchedNodeCache;
-
-// Resolve WTM once at module load (avoids repeated require lookup on every flush)
-let WTM = null;
-try {
-  WTM = require('./WTM');
-} catch (e) { /* WTM not available — skip */ }
+// Step 4: Replace node-cache in Node's require system
+// After this, any file that does require('node-cache') gets TrackedNodeCache
+require.cache[require.resolve('node-cache')].exports = TrackedNodeCache;
 
 /**
- * Flushes ALL NodeCache instances in the process + WTM HTTP response cache.
- * @returns {{ nodeCaches: number, totalKeys: number, wtmKeys: number }}
+ * Clears ALL cached data across the entire service.
+ * Called by CacheResetListener when a flush signal is received from Kafka.
  */
 const flushAll = () => {
   let totalKeys = 0;
-  allCaches.forEach((c) => {
+
+  // Clear every NodeCache instance (providers, WTM, BIDTenant, etc.)
+  allCaches.forEach((cache) => {
     try {
-      totalKeys += c.keys().length;
-      c.flushAll();
-    } catch (e) { /* ignore dead cache reference */ }
+      totalKeys += cache.keys().length;
+      cache.flushAll();
+    } catch (e) { /* skip if cache was garbage collected */ }
   });
 
-  let wtmKeys = 0;
-  if (WTM && typeof WTM.flushCache === 'function') {
-    try {
-      wtmKeys = WTM.flushCache();
-    } catch (e) { /* ignore */ }
-  }
-
-  return { nodeCaches: allCaches.length, totalKeys, wtmKeys };
+  return { nodeCaches: allCaches.length, totalKeys };
 };
 
-module.exports = { flushAll, allCaches };
+module.exports = { flushAll };

--- a/CacheRegistry.js
+++ b/CacheRegistry.js
@@ -13,27 +13,28 @@
  *     require('blockid-nodejs-helpers/CacheRegistry');
  *
  *   That's it. All caches created after this line are automatically tracked.
+ *   Safe no-op if node-cache is not installed.
  */
 
-// Step 1: Save the real NodeCache constructor
-const RealNodeCache = require('node-cache');
-
-// Step 2: Keep a list of all cache instances
 const allCaches = [];
 
-// Step 3: Create a wrapper that saves each new instance to the list
-function TrackedNodeCache(...args) {
-  const instance = new RealNodeCache(...args);
-  allCaches.push(instance);
-  return instance;
-}
-TrackedNodeCache.prototype = RealNodeCache.prototype;
+// Patch node-cache if available — safe no-op if not installed
+try {
+  const RealNodeCache = require('node-cache');
 
-// Step 4: Replace node-cache in Node's require system
-// After this, any file that does require('node-cache') gets TrackedNodeCache
-const nodeCacheEntry = require.cache[require.resolve('node-cache')];
-if (nodeCacheEntry) {
-  nodeCacheEntry.exports = TrackedNodeCache;
+  function TrackedNodeCache(...args) {
+    const instance = new RealNodeCache(...args);
+    allCaches.push(instance);
+    return instance;
+  }
+  TrackedNodeCache.prototype = RealNodeCache.prototype;
+
+  const nodeCacheEntry = require.cache[require.resolve('node-cache')];
+  if (nodeCacheEntry) {
+    nodeCacheEntry.exports = TrackedNodeCache;
+  }
+} catch (e) {
+  // node-cache not installed — flushAll() will be a no-op
 }
 
 /**
@@ -43,7 +44,6 @@ if (nodeCacheEntry) {
 const flushAll = () => {
   let totalKeys = 0;
 
-  // Clear every NodeCache instance (providers, WTM, BIDTenant, etc.)
   allCaches.forEach((cache) => {
     try {
       totalKeys += cache.keys().length;

--- a/CacheRegistry.js
+++ b/CacheRegistry.js
@@ -45,7 +45,7 @@ const flushAll = () => {
     try {
       totalKeys += cache.keys().length;
       cache.flushAll();
-    } catch (e) { /* skip if cache was garbage collected */ }
+    } catch (e) { /* skip — cache instance may be in a bad state */ }
   });
 
   return { nodeCaches: allCaches.length, totalKeys };

--- a/CacheRegistry.js
+++ b/CacheRegistry.js
@@ -31,7 +31,10 @@ TrackedNodeCache.prototype = RealNodeCache.prototype;
 
 // Step 4: Replace node-cache in Node's require system
 // After this, any file that does require('node-cache') gets TrackedNodeCache
-require.cache[require.resolve('node-cache')].exports = TrackedNodeCache;
+const nodeCacheEntry = require.cache[require.resolve('node-cache')];
+if (nodeCacheEntry) {
+  nodeCacheEntry.exports = TrackedNodeCache;
+}
 
 /**
  * Clears ALL cached data across the entire service.

--- a/CacheRegistry.js
+++ b/CacheRegistry.js
@@ -10,16 +10,25 @@
  * When flushAll() is called, every NodeCache instance + WTM cache is cleared.
  */
 
-const NodeCache = require('node-cache');
+const OriginalNodeCache = require('node-cache');
 
 const allCaches = [];
 
-// Patch NodeCache constructor to auto-register every instance
-const _originalInit = NodeCache.prototype.init;
-NodeCache.prototype.init = function (...args) {
-  allCaches.push(this);
-  return _originalInit.apply(this, args);
-};
+// Replace node-cache module export with a wrapper that captures every instance.
+// node-cache v5.x does NOT have a `.init()` prototype method, so patching the
+// constructor via the require cache is the only reliable interception point.
+function PatchedNodeCache(...args) {
+  const instance = new OriginalNodeCache(...args);
+  allCaches.push(instance);
+  return instance;
+}
+
+// Preserve prototype chain so instanceof checks still work
+PatchedNodeCache.prototype = OriginalNodeCache.prototype;
+PatchedNodeCache.prototype.constructor = PatchedNodeCache;
+
+// Replace in Node's require cache so all subsequent `require('node-cache')` get the patched version
+require.cache[require.resolve('node-cache')].exports = PatchedNodeCache;
 
 // Resolve WTM once at module load (avoids repeated require lookup on every flush)
 let WTM = null;

--- a/CacheRegistry.js
+++ b/CacheRegistry.js
@@ -34,6 +34,7 @@ try {
     nodeCacheEntry.exports = TrackedNodeCache;
   }
 } catch (e) {
+  if (e.code !== 'MODULE_NOT_FOUND') throw e;
   // node-cache not installed — flushAll() will be a no-op
 }
 

--- a/CacheRegistry.js
+++ b/CacheRegistry.js
@@ -46,7 +46,7 @@ const flushAll = () => {
 
   allCaches.forEach((cache) => {
     try {
-      totalKeys += cache.keys().length;
+      totalKeys += (cache.getStats && cache.getStats().keys) || cache.keys().length;
       cache.flushAll();
     } catch (e) { /* skip — cache instance may be in a bad state */ }
   });

--- a/CacheResetListener.js
+++ b/CacheResetListener.js
@@ -49,13 +49,14 @@ const initialize = async ({ kafkaConfig, serviceName, logger }) => {
     return;
   }
 
+  let consumer = null;
   try {
     // Each pod gets a unique group so every pod receives every message (fan-out)
     const podId = process.env.HOSTNAME || require('crypto').randomUUID();
     const groupId = `${TOPIC_NAME}-${serviceName}-${podId}`;
 
-    const kafka = new Kafka({ clientId: `client-${TOPIC_NAME}`, brokers });
-    const consumer = kafka.consumer({ groupId });
+    const kafka = new Kafka({ clientId: `${TOPIC_NAME}-${serviceName}-${podId}`, brokers });
+    consumer = kafka.consumer({ groupId });
 
     await consumer.connect();
     await consumer.subscribe({ topic: TOPIC_NAME, fromBeginning: false });
@@ -97,6 +98,10 @@ const initialize = async ({ kafkaConfig, serviceName, logger }) => {
     initialized = true;
     logger.info(`[CacheResetListener] Listening on topic ${TOPIC_NAME} (groupId: ${groupId})`);
   } catch (error) {
+    // Clean up consumer on partial initialization failure
+    if (consumer) {
+      try { await consumer.disconnect(); } catch (e) { /* best effort */ }
+    }
     logger.error(`[CacheResetListener] Initialization failed: ${error.message}`);
   }
 };

--- a/CacheResetListener.js
+++ b/CacheResetListener.js
@@ -9,7 +9,7 @@
  *
  * Options:
  *   - kafkaConfig: { brokers: string[], kafka_off?: boolean }
- *   - serviceName: e.g. 'adminapi', 'caas', 'users-mgmt' (used for groupId + target matching)
+ *   - serviceName: e.g. 'adminapi', 'caas', 'users-mgmt' (used for groupId)
  *   - logger: Winston logger instance (must have .info, .warn, .error)
  *   - onFlush: optional callback invoked after caches are flushed (for service-specific cleanup)
  */
@@ -87,20 +87,6 @@ const initialize = async ({ kafkaConfig, serviceName, logger, onFlush }) => {
           // Replay protection
           if (payload.timestamp && Math.abs(Date.now() - payload.timestamp) > REPLAY_WINDOW_MS) {
             logger.warn(`[CacheResetListener] Rejecting stale message (age: ${Date.now() - payload.timestamp}ms)`);
-            return;
-          }
-
-          // Target filtering
-          if (payload.targets && !Array.isArray(payload.targets)) {
-            logger.warn('[CacheResetListener] Ignoring message with invalid targets');
-            return;
-          }
-
-          const targets = payload.targets;
-          const shouldFlush = !targets || targets.length === 0 || targets.includes(serviceName);
-
-          if (!shouldFlush) {
-            logger.info(`[CacheResetListener] Not targeted (targets: ${JSON.stringify(targets)}), skipping`);
             return;
           }
 

--- a/CacheResetListener.js
+++ b/CacheResetListener.js
@@ -9,26 +9,25 @@
  *   3. When a message arrives from CaaS, calls CacheRegistry.flushAll()
  *   4. All in-memory caches are cleared — next request fetches fresh data
  *
- * USAGE (in each service's CacheResetConsumer.js):
+ * USAGE:
  *   const CacheResetListener = require('blockid-nodejs-helpers/CacheResetListener');
  *   await CacheResetListener.initialize({ kafkaConfig, serviceName, logger });
  */
 
+const { Kafka } = require('kafkajs');
 const CacheRegistry = require('./CacheRegistry');
 
 const TOPIC_NAME = 'platform_cache_reset';
-const REPLAY_WINDOW_MS = 30000; // allow up to 30s clock skew in either direction
+const REPLAY_WINDOW_MS = 30000;
 
 let initialized = false;
 
 const initialize = async ({ kafkaConfig, serviceName, logger }) => {
-  // Only initialize once per process
   if (initialized) {
     logger.info('[CacheResetListener] Already initialized, skipping');
     return;
   }
 
-  // Skip if Kafka is not configured or disabled
   if (!kafkaConfig || kafkaConfig.kafka_off === true) {
     logger.info('[CacheResetListener] Kafka not available or disabled, skipping');
     return;
@@ -40,20 +39,9 @@ const initialize = async ({ kafkaConfig, serviceName, logger }) => {
     return;
   }
 
-  // kafkajs is optional — service must have it installed
-  let Kafka;
-  try {
-    ({ Kafka } = require('kafkajs'));
-  } catch (e) {
-    if (e.code !== 'MODULE_NOT_FOUND') throw e;
-    logger.info('[CacheResetListener] kafkajs not installed, skipping');
-    return;
-  }
-
   let consumer = null;
   try {
-    // Each pod gets a unique group so every pod receives every message (fan-out)
-    const podId = process.env.HOSTNAME || require('crypto').randomBytes(8).toString('hex');
+    const podId = process.env.HOSTNAME || require('crypto').randomUUID();
     const groupId = `${TOPIC_NAME}-${serviceName}-${podId}`;
 
     const kafka = new Kafka({ clientId: `${TOPIC_NAME}-${serviceName}-${podId}`, brokers });
@@ -72,22 +60,18 @@ const initialize = async ({ kafkaConfig, serviceName, logger }) => {
       eachMessage: async ({ message }) => {
         try {
           if (message.value == null) return;
-
           const payload = JSON.parse(message.value.toString());
 
-          // Only accept messages from CaaS
           if (payload.source !== 'caas') {
             logger.warn(`[CacheResetListener] Ignoring message from: ${payload.source}`);
             return;
           }
 
-          // Reject old/replayed messages (or missing timestamp)
-          if (!Number.isFinite(payload.timestamp) || Math.abs(Date.now() - payload.timestamp) > REPLAY_WINDOW_MS) {
-            logger.warn(`[CacheResetListener] Rejecting message — invalid or stale timestamp`);
+          if (payload.timestamp && Math.abs(Date.now() - payload.timestamp) > REPLAY_WINDOW_MS) {
+            logger.warn('[CacheResetListener] Rejecting stale message');
             return;
           }
 
-          // Flush all caches
           const result = CacheRegistry.flushAll();
           logger.info(`[CacheResetListener] Cache flush complete: ${result.nodeCaches} caches, ${result.totalKeys} keys cleared`);
         } catch (error) {
@@ -99,7 +83,6 @@ const initialize = async ({ kafkaConfig, serviceName, logger }) => {
     initialized = true;
     logger.info(`[CacheResetListener] Listening on topic ${TOPIC_NAME} (groupId: ${groupId})`);
   } catch (error) {
-    // Clean up consumer on partial initialization failure
     if (consumer) {
       try { await consumer.disconnect(); } catch (e) { /* best effort */ }
     }

--- a/CacheResetListener.js
+++ b/CacheResetListener.js
@@ -1,40 +1,36 @@
 'use strict';
 
 /**
- * CacheResetListener — Kafka-based distributed cache flush for all 1Kosmos microservices.
+ * CacheResetListener — Listens for "flush your caches" signal on Kafka.
  *
- * Usage:
+ * HOW IT WORKS:
+ *   1. Connects to Kafka topic 'platform_cache_reset'
+ *   2. Each pod gets its own consumer group (so every pod receives every message)
+ *   3. When a message arrives from CaaS, calls CacheRegistry.flushAll()
+ *   4. All in-memory caches are cleared — next request fetches fresh data
+ *
+ * USAGE (in each service's CacheResetConsumer.js):
  *   const CacheResetListener = require('blockid-nodejs-helpers/CacheResetListener');
- *   CacheResetListener.initialize({ kafkaConfig, serviceName, logger });
- *
- * Options:
- *   - kafkaConfig: { brokers: string[], kafka_off?: boolean }
- *   - serviceName: e.g. 'adminapi', 'caas', 'users-mgmt' (used for groupId)
- *   - logger: Winston logger instance (must have .info, .warn, .error)
- *   - onFlush: optional callback invoked after caches are flushed (for service-specific cleanup)
+ *   await CacheResetListener.initialize({ kafkaConfig, serviceName, logger });
  */
 
 const CacheRegistry = require('./CacheRegistry');
 
 const TOPIC_NAME = 'platform_cache_reset';
-const REPLAY_WINDOW_MS = 30000;
+const REPLAY_WINDOW_MS = 30000; // reject messages older than 30 seconds
 
-let consumer = null;
 let initialized = false;
 
-const initialize = async ({ kafkaConfig, serviceName, logger, onFlush }) => {
+const initialize = async ({ kafkaConfig, serviceName, logger }) => {
+  // Only initialize once per process
   if (initialized) {
     logger.info('[CacheResetListener] Already initialized, skipping');
     return;
   }
 
-  if (!kafkaConfig) {
-    logger.info('[CacheResetListener] No kafkaConfig provided, skipping');
-    return;
-  }
-
-  if (kafkaConfig.kafka_off === true) {
-    logger.info('[CacheResetListener] Kafka is disabled (kafka_off), skipping');
+  // Skip if Kafka is not configured or disabled
+  if (!kafkaConfig || kafkaConfig.kafka_off === true) {
+    logger.info('[CacheResetListener] Kafka not available or disabled, skipping');
     return;
   }
 
@@ -44,30 +40,29 @@ const initialize = async ({ kafkaConfig, serviceName, logger, onFlush }) => {
     return;
   }
 
+  // kafkajs is optional — service must have it installed
   let Kafka;
   try {
     ({ Kafka } = require('kafkajs'));
   } catch (e) {
-    logger.error('[CacheResetListener] kafkajs not installed in this service, skipping');
+    logger.error('[CacheResetListener] kafkajs not installed, skipping');
     return;
   }
 
   try {
+    // Each pod gets a unique group so every pod receives every message (fan-out)
     const podId = process.env.HOSTNAME || require('crypto').randomUUID();
     const groupId = `${TOPIC_NAME}-${serviceName}-${podId}`;
 
-    const kafkaClient = new Kafka({
-      clientId: `client-${TOPIC_NAME}`,
-      brokers,
-    });
+    const kafka = new Kafka({ clientId: `client-${TOPIC_NAME}`, brokers });
+    const consumer = kafka.consumer({ groupId });
 
-    consumer = kafkaClient.consumer({ groupId });
     await consumer.connect();
     await consumer.subscribe({ topic: TOPIC_NAME, fromBeginning: false });
 
     consumer.on(consumer.events.CRASH, (event) => {
       if (!event.payload.restart) {
-        logger.error('[CacheResetListener] Consumer crashed and will not restart — cache flush disabled until service restart');
+        logger.error('[CacheResetListener] Consumer crashed — cache flush disabled until restart');
       }
     });
 
@@ -78,26 +73,21 @@ const initialize = async ({ kafkaConfig, serviceName, logger, onFlush }) => {
 
           const payload = JSON.parse(message.value.toString());
 
-          // Source validation
+          // Only accept messages from CaaS
           if (payload.source !== 'caas') {
-            logger.warn(`[CacheResetListener] Ignoring message from untrusted source: ${payload.source}`);
+            logger.warn(`[CacheResetListener] Ignoring message from: ${payload.source}`);
             return;
           }
 
-          // Replay protection
+          // Reject old/replayed messages
           if (payload.timestamp && Math.abs(Date.now() - payload.timestamp) > REPLAY_WINDOW_MS) {
             logger.warn(`[CacheResetListener] Rejecting stale message (age: ${Date.now() - payload.timestamp}ms)`);
             return;
           }
 
-          // Flush all caches (NodeCache instances + WTM)
+          // Flush all caches
           const result = CacheRegistry.flushAll();
-          logger.info(`[CacheResetListener] Cache flush complete: ${result.nodeCaches} caches, ${result.totalKeys} keys cleared, WTM: ${result.wtmKeys} keys`);
-
-          // Service-specific flush callback
-          if (onFlush && typeof onFlush === 'function') {
-            onFlush();
-          }
+          logger.info(`[CacheResetListener] Cache flush complete: ${result.nodeCaches} caches, ${result.totalKeys} keys cleared`);
         } catch (error) {
           logger.error(`[CacheResetListener] Error processing message: ${error.message}`);
         }
@@ -107,11 +97,6 @@ const initialize = async ({ kafkaConfig, serviceName, logger, onFlush }) => {
     initialized = true;
     logger.info(`[CacheResetListener] Listening on topic ${TOPIC_NAME} (groupId: ${groupId})`);
   } catch (error) {
-    // Clean up dangling consumer on partial failure
-    if (consumer) {
-      try { await consumer.disconnect(); } catch (e) { /* ignore */ }
-      consumer = null;
-    }
     logger.error(`[CacheResetListener] Initialization failed: ${error.message}`);
   }
 };

--- a/CacheResetListener.js
+++ b/CacheResetListener.js
@@ -52,7 +52,7 @@ const initialize = async ({ kafkaConfig, serviceName, logger }) => {
   let consumer = null;
   try {
     // Each pod gets a unique group so every pod receives every message (fan-out)
-    const podId = process.env.HOSTNAME || require('crypto').randomUUID();
+    const podId = process.env.HOSTNAME || require('crypto').randomBytes(8).toString('hex');
     const groupId = `${TOPIC_NAME}-${serviceName}-${podId}`;
 
     const kafka = new Kafka({ clientId: `${TOPIC_NAME}-${serviceName}-${podId}`, brokers });

--- a/CacheResetListener.js
+++ b/CacheResetListener.js
@@ -45,6 +45,7 @@ const initialize = async ({ kafkaConfig, serviceName, logger }) => {
   try {
     ({ Kafka } = require('kafkajs'));
   } catch (e) {
+    if (e.code !== 'MODULE_NOT_FOUND') throw e;
     logger.info('[CacheResetListener] kafkajs not installed, skipping');
     return;
   }

--- a/CacheResetListener.js
+++ b/CacheResetListener.js
@@ -1,0 +1,137 @@
+'use strict';
+
+/**
+ * CacheResetListener — Kafka-based distributed cache flush for all 1Kosmos microservices.
+ *
+ * Usage (one line in each service's index.js after Kafka config is fetched):
+ *   const CacheResetListener = require('blockid-nodejs-helpers/CacheResetListener');
+ *   CacheResetListener.initialize({ kafkaConfig, serviceName, logger, onFlush });
+ *
+ * Options:
+ *   - kafkaConfig: { brokers: string[], kafka_off?: boolean }
+ *   - serviceName: e.g. 'adminapi', 'caas', 'users-mgmt' (used for groupId + target matching)
+ *   - logger: Winston logger instance (must have .info, .warn, .error)
+ *   - onFlush: optional callback invoked after WTM cache is flushed (for service-specific caches)
+ *   - verifySignature: optional async function(payload) => boolean for ECDSA verification
+ */
+
+const WTM = require('./WTM');
+
+const TOPIC_NAME = 'platform_cache_reset';
+const REPLAY_WINDOW_MS = 30000;
+
+let consumer = null;
+let initialized = false;
+
+const initialize = async ({ kafkaConfig, serviceName, logger, onFlush, verifySignature }) => {
+  if (initialized) {
+    logger.info('[CacheResetListener] Already initialized, skipping');
+    return;
+  }
+
+  if (!kafkaConfig) {
+    logger.info('[CacheResetListener] No kafkaConfig provided, skipping');
+    return;
+  }
+
+  if (kafkaConfig.kafka_off === true) {
+    logger.info('[CacheResetListener] Kafka is disabled (kafka_off), skipping');
+    return;
+  }
+
+  const { brokers } = kafkaConfig;
+  if (!Array.isArray(brokers) || brokers.length === 0) {
+    logger.info('[CacheResetListener] No brokers configured, skipping');
+    return;
+  }
+
+  let Kafka;
+  try {
+    ({ Kafka } = require('kafkajs'));
+  } catch (e) {
+    logger.error('[CacheResetListener] kafkajs not installed in this service, skipping');
+    return;
+  }
+
+  try {
+    const podId = process.env.HOSTNAME || require('crypto').randomUUID();
+    const groupId = `${TOPIC_NAME}-${serviceName}-${podId}`;
+
+    const kafkaClient = new Kafka({
+      clientId: `client-${TOPIC_NAME}`,
+      brokers,
+    });
+
+    consumer = kafkaClient.consumer({ groupId });
+    await consumer.connect();
+    await consumer.subscribe({ topic: TOPIC_NAME, fromBeginning: false });
+
+    consumer.on(consumer.events.CRASH, (event) => {
+      if (!event.payload.restart) logger.error('[CacheResetListener] Connection to KafkaJS is lost, please restart this service');
+    });
+
+    await consumer.run({
+      eachMessage: async ({ message }) => {
+        try {
+          if (message.value == null) return;
+
+          const payload = JSON.parse(message.value.toString());
+
+          // Signature verification (if provided)
+          if (verifySignature) {
+            const isValid = await verifySignature(payload);
+            if (!isValid) {
+              logger.warn('[CacheResetListener] Rejecting unverified message');
+              return;
+            }
+          } else {
+            // Fallback: basic source check
+            if (payload.source !== 'caas') {
+              logger.warn(`[CacheResetListener] Ignoring message from untrusted source: ${payload.source}`);
+              return;
+            }
+          }
+
+          // Replay protection (if signature has timestamp)
+          if (payload.timestamp && Math.abs(Date.now() - payload.timestamp) > REPLAY_WINDOW_MS) {
+            logger.warn(`[CacheResetListener] Rejecting stale message (age: ${Date.now() - payload.timestamp}ms)`);
+            return;
+          }
+
+          if (payload.targets && !Array.isArray(payload.targets)) {
+            logger.warn('[CacheResetListener] Ignoring message with invalid targets');
+            return;
+          }
+
+          const targets = payload.targets;
+          const shouldFlush = !targets || targets.length === 0 || targets.includes(serviceName);
+
+          if (!shouldFlush) {
+            logger.info(`[CacheResetListener] Not targeted (targets: ${JSON.stringify(targets)}), skipping`);
+            return;
+          }
+
+          // Flush WTM cache
+          const wtmKeys = WTM.flushCache();
+          logger.info(`[CacheResetListener] WTM cache flushed (${wtmKeys} keys cleared)`);
+
+          // Call service-specific flush callback
+          if (onFlush && typeof onFlush === 'function') {
+            onFlush();
+          }
+
+          logger.info(`[CacheResetListener] Cache flush complete for ${serviceName}`);
+        } catch (error) {
+          logger.error(`[CacheResetListener] Error processing message: ${error}`);
+        }
+      },
+    });
+
+    initialized = true;
+    logger.info(`[CacheResetListener] Listening on topic ${TOPIC_NAME} (groupId: ${groupId})`);
+  } catch (error) {
+    logger.error(`[CacheResetListener] Initialization failed: ${error.message}`);
+  }
+};
+
+module.exports = { initialize };

--- a/CacheResetListener.js
+++ b/CacheResetListener.js
@@ -14,7 +14,6 @@
  *   await CacheResetListener.initialize({ kafkaConfig, serviceName, logger });
  */
 
-const { Kafka } = require('kafkajs');
 const CacheRegistry = require('./CacheRegistry');
 
 const TOPIC_NAME = 'platform_cache_reset';
@@ -44,6 +43,7 @@ const initialize = async ({ kafkaConfig, serviceName, logger }) => {
     const podId = process.env.HOSTNAME || require('crypto').randomUUID();
     const groupId = `${TOPIC_NAME}-${serviceName}-${podId}`;
 
+    const { Kafka } = require('kafkajs');
     const kafka = new Kafka({ clientId: `${TOPIC_NAME}-${serviceName}-${podId}`, brokers });
     consumer = kafka.consumer({ groupId });
 

--- a/CacheResetListener.js
+++ b/CacheResetListener.js
@@ -16,6 +16,7 @@
  */
 
 const WTM = require('./WTM');
+const CacheRegistry = require('./CacheRegistry');
 
 const TOPIC_NAME = 'platform_cache_reset';
 const REPLAY_WINDOW_MS = 30000;
@@ -111,16 +112,14 @@ const initialize = async ({ kafkaConfig, serviceName, logger, onFlush, verifySig
             return;
           }
 
-          // Flush WTM cache
-          const wtmKeys = WTM.flushCache();
-          logger.info(`[CacheResetListener] WTM cache flushed (${wtmKeys} keys cleared)`);
+          // Flush all caches (WTM + all NodeCache instances)
+          const result = CacheRegistry.flushAll();
+          logger.info(`[CacheResetListener] Cache flush complete: ${result.nodeCaches} caches, ${result.totalKeys} keys cleared, WTM: ${result.wtmKeys} keys`);
 
-          // Call service-specific flush callback
+          // Call service-specific flush callback if provided
           if (onFlush && typeof onFlush === 'function') {
             onFlush();
           }
-
-          logger.info(`[CacheResetListener] Cache flush complete for ${serviceName}`);
         } catch (error) {
           logger.error(`[CacheResetListener] Error processing message: ${error}`);
         }

--- a/CacheResetListener.js
+++ b/CacheResetListener.js
@@ -12,7 +12,6 @@
  *   - serviceName: e.g. 'adminapi', 'caas', 'users-mgmt' (used for groupId + target matching)
  *   - logger: Winston logger instance (must have .info, .warn, .error)
  *   - onFlush: optional callback invoked after caches are flushed (for service-specific cleanup)
- *   - verifySignature: optional async function(payload) => boolean for ECDSA verification
  */
 
 const CacheRegistry = require('./CacheRegistry');
@@ -23,7 +22,7 @@ const REPLAY_WINDOW_MS = 30000;
 let consumer = null;
 let initialized = false;
 
-const initialize = async ({ kafkaConfig, serviceName, logger, onFlush, verifySignature }) => {
+const initialize = async ({ kafkaConfig, serviceName, logger, onFlush }) => {
   if (initialized) {
     logger.info('[CacheResetListener] Already initialized, skipping');
     return;
@@ -79,14 +78,8 @@ const initialize = async ({ kafkaConfig, serviceName, logger, onFlush, verifySig
 
           const payload = JSON.parse(message.value.toString());
 
-          // Signature verification (if provided)
-          if (verifySignature) {
-            const isValid = await verifySignature(payload);
-            if (!isValid) {
-              logger.warn('[CacheResetListener] Rejecting unverified message');
-              return;
-            }
-          } else if (payload.source !== 'caas') {
+          // Source validation
+          if (payload.source !== 'caas') {
             logger.warn(`[CacheResetListener] Ignoring message from untrusted source: ${payload.source}`);
             return;
           }

--- a/CacheResetListener.js
+++ b/CacheResetListener.js
@@ -3,19 +3,18 @@
 /**
  * CacheResetListener — Kafka-based distributed cache flush for all 1Kosmos microservices.
  *
- * Usage (one line in each service's index.js after Kafka config is fetched):
+ * Usage:
  *   const CacheResetListener = require('blockid-nodejs-helpers/CacheResetListener');
- *   CacheResetListener.initialize({ kafkaConfig, serviceName, logger, onFlush });
+ *   CacheResetListener.initialize({ kafkaConfig, serviceName, logger });
  *
  * Options:
  *   - kafkaConfig: { brokers: string[], kafka_off?: boolean }
  *   - serviceName: e.g. 'adminapi', 'caas', 'users-mgmt' (used for groupId + target matching)
  *   - logger: Winston logger instance (must have .info, .warn, .error)
- *   - onFlush: optional callback invoked after WTM cache is flushed (for service-specific caches)
+ *   - onFlush: optional callback invoked after caches are flushed (for service-specific cleanup)
  *   - verifySignature: optional async function(payload) => boolean for ECDSA verification
  */
 
-const WTM = require('./WTM');
 const CacheRegistry = require('./CacheRegistry');
 
 const TOPIC_NAME = 'platform_cache_reset';
@@ -68,7 +67,9 @@ const initialize = async ({ kafkaConfig, serviceName, logger, onFlush, verifySig
     await consumer.subscribe({ topic: TOPIC_NAME, fromBeginning: false });
 
     consumer.on(consumer.events.CRASH, (event) => {
-      if (!event.payload.restart) logger.error('[CacheResetListener] Connection to KafkaJS is lost, please restart this service');
+      if (!event.payload.restart) {
+        logger.error('[CacheResetListener] Consumer crashed and will not restart — cache flush disabled until service restart');
+      }
     });
 
     await consumer.run({
@@ -85,20 +86,18 @@ const initialize = async ({ kafkaConfig, serviceName, logger, onFlush, verifySig
               logger.warn('[CacheResetListener] Rejecting unverified message');
               return;
             }
-          } else {
-            // Fallback: basic source check
-            if (payload.source !== 'caas') {
-              logger.warn(`[CacheResetListener] Ignoring message from untrusted source: ${payload.source}`);
-              return;
-            }
+          } else if (payload.source !== 'caas') {
+            logger.warn(`[CacheResetListener] Ignoring message from untrusted source: ${payload.source}`);
+            return;
           }
 
-          // Replay protection (if signature has timestamp)
+          // Replay protection
           if (payload.timestamp && Math.abs(Date.now() - payload.timestamp) > REPLAY_WINDOW_MS) {
             logger.warn(`[CacheResetListener] Rejecting stale message (age: ${Date.now() - payload.timestamp}ms)`);
             return;
           }
 
+          // Target filtering
           if (payload.targets && !Array.isArray(payload.targets)) {
             logger.warn('[CacheResetListener] Ignoring message with invalid targets');
             return;
@@ -112,16 +111,16 @@ const initialize = async ({ kafkaConfig, serviceName, logger, onFlush, verifySig
             return;
           }
 
-          // Flush all caches (WTM + all NodeCache instances)
+          // Flush all caches (NodeCache instances + WTM)
           const result = CacheRegistry.flushAll();
           logger.info(`[CacheResetListener] Cache flush complete: ${result.nodeCaches} caches, ${result.totalKeys} keys cleared, WTM: ${result.wtmKeys} keys`);
 
-          // Call service-specific flush callback if provided
+          // Service-specific flush callback
           if (onFlush && typeof onFlush === 'function') {
             onFlush();
           }
         } catch (error) {
-          logger.error(`[CacheResetListener] Error processing message: ${error}`);
+          logger.error(`[CacheResetListener] Error processing message: ${error.message}`);
         }
       },
     });
@@ -129,6 +128,11 @@ const initialize = async ({ kafkaConfig, serviceName, logger, onFlush, verifySig
     initialized = true;
     logger.info(`[CacheResetListener] Listening on topic ${TOPIC_NAME} (groupId: ${groupId})`);
   } catch (error) {
+    // Clean up dangling consumer on partial failure
+    if (consumer) {
+      try { await consumer.disconnect(); } catch (e) { /* ignore */ }
+      consumer = null;
+    }
     logger.error(`[CacheResetListener] Initialization failed: ${error.message}`);
   }
 };

--- a/CacheResetListener.js
+++ b/CacheResetListener.js
@@ -17,7 +17,7 @@
 const CacheRegistry = require('./CacheRegistry');
 
 const TOPIC_NAME = 'platform_cache_reset';
-const REPLAY_WINDOW_MS = 30000; // reject messages more than 30 seconds old or in the future
+const REPLAY_WINDOW_MS = 30000; // allow up to 30s clock skew in either direction
 
 let initialized = false;
 
@@ -81,7 +81,7 @@ const initialize = async ({ kafkaConfig, serviceName, logger }) => {
           }
 
           // Reject old/replayed messages (or missing timestamp)
-          if (!payload.timestamp || typeof payload.timestamp !== 'number' || Math.abs(Date.now() - payload.timestamp) > REPLAY_WINDOW_MS) {
+          if (!Number.isFinite(payload.timestamp) || Math.abs(Date.now() - payload.timestamp) > REPLAY_WINDOW_MS) {
             logger.warn(`[CacheResetListener] Rejecting message — invalid or stale timestamp`);
             return;
           }

--- a/CacheResetListener.js
+++ b/CacheResetListener.js
@@ -17,7 +17,7 @@
 const CacheRegistry = require('./CacheRegistry');
 
 const TOPIC_NAME = 'platform_cache_reset';
-const REPLAY_WINDOW_MS = 30000; // reject messages older than 30 seconds
+const REPLAY_WINDOW_MS = 30000; // reject messages more than 30 seconds old or in the future
 
 let initialized = false;
 
@@ -45,7 +45,7 @@ const initialize = async ({ kafkaConfig, serviceName, logger }) => {
   try {
     ({ Kafka } = require('kafkajs'));
   } catch (e) {
-    logger.error('[CacheResetListener] kafkajs not installed, skipping');
+    logger.info('[CacheResetListener] kafkajs not installed, skipping');
     return;
   }
 

--- a/CacheResetListener.js
+++ b/CacheResetListener.js
@@ -79,9 +79,9 @@ const initialize = async ({ kafkaConfig, serviceName, logger }) => {
             return;
           }
 
-          // Reject old/replayed messages
-          if (payload.timestamp && Math.abs(Date.now() - payload.timestamp) > REPLAY_WINDOW_MS) {
-            logger.warn(`[CacheResetListener] Rejecting stale message (age: ${Date.now() - payload.timestamp}ms)`);
+          // Reject old/replayed messages (or missing timestamp)
+          if (!payload.timestamp || typeof payload.timestamp !== 'number' || Math.abs(Date.now() - payload.timestamp) > REPLAY_WINDOW_MS) {
+            logger.warn(`[CacheResetListener] Rejecting message — invalid or stale timestamp`);
             return;
           }
 

--- a/WTM.js
+++ b/WTM.js
@@ -161,7 +161,14 @@ const executeRequest = async (object) => {
 };
 
 
+const flushCache = () => {
+    const keys = cache.keys();
+    cache.flushAll();
+    return keys.length;
+};
+
 module.exports = {
     executeRequest,
-    createRequestID
+    createRequestID,
+    flushCache
 };

--- a/WTM.js
+++ b/WTM.js
@@ -161,14 +161,7 @@ const executeRequest = async (object) => {
 };
 
 
-const flushCache = () => {
-    const keys = cache.keys();
-    cache.flushAll();
-    return keys.length;
-};
-
 module.exports = {
     executeRequest,
-    createRequestID,
-    flushCache
+    createRequestID
 };


### PR DESCRIPTION
## Summary

Two new files that enable distributed cache flush across all 1Kosmos Node.js services. When an admin triggers flush via CaaS, every pod clears its in-memory caches immediately.

## Files (2 new, 0 modified)

### CacheRegistry.js (44 lines)

Replaces `node-cache` with a wrapper that tracks every instance. On flush, clears them all.

```js
require('blockid-nodejs-helpers/CacheRegistry'); // FIRST require in service
```

### CacheResetListener.js (93 lines)

Kafka consumer — listens on `platform_cache_reset` topic, calls `CacheRegistry.flushAll()` on signal.

```js
const CacheResetListener = require('blockid-nodejs-helpers/CacheResetListener');
await CacheResetListener.initialize({ kafkaConfig, serviceName, logger });
```

## How it works

1. CaaS publishes message to `platform_cache_reset` Kafka topic
2. Every pod receives it (unique consumer groupId per pod = fan-out)
3. Each pod calls `CacheRegistry.flushAll()` — clears all NodeCache instances
4. Next request fetches fresh data from source

## Trigger

```
GET /caas/environment?resetCaching=true
```

Requires system/service level license.

## JIRA

https://onekosmos.atlassian.net/browse/PL30-413