### PR TITLE
fix: use DNS-compatible topic name (platform-cache-reset)

### DIFF
--- a/CacheResetListener.js
+++ b/CacheResetListener.js
@@ -4,7 +4,7 @@
  * CacheResetListener — Listens for "flush your caches" signal on Kafka.
  *
  * HOW IT WORKS:
- *   1. Connects to Kafka topic 'platform_cache_reset'
+ *   1. Connects to Kafka topic 'platform-cache-reset'
  *   2. Each pod gets its own consumer group (so every pod receives every message)
  *   3. When a message arrives from CaaS, calls CacheRegistry.flushAll()
  *   4. All in-memory caches are cleared — next request fetches fresh data
@@ -16,7 +16,7 @@
 
 const CacheRegistry = require('./CacheRegistry');
 
-const TOPIC_NAME = 'platform_cache_reset';
+const TOPIC_NAME = 'platform-cache-reset';
 const REPLAY_WINDOW_MS = 30000;
 
 let initialized = false;


### PR DESCRIPTION
Strimzi KafkaTopic CRD requires DNS-1123 compliant names (lowercase, hyphens, no underscores).

Changed `platform_cache_reset` → `platform-cache-reset` in CacheResetListener.

**Note:** The key in CaaS `kafka_config.topics` remains `platform_cache_reset` (underscore) — only the actual Kafka topic name (value) uses hyphens. Same pattern as `administrator_actions: 'administrator-actions'`.