### PR TITLE
feat(WTM): support AbortController signal for request cancellation

### DIFF
--- a/WTM.js
+++ b/WTM.js
@@ -85,6 +85,12 @@ const executeRequest = async (object) => {
         request.timeout = object.timeout;
     }
 
+    // Support AbortController signal for request cancellation.
+    // Caller passes { signal: abortController.signal } to allow aborting the request externally.
+    if (object.signal) {
+        request.signal = object.signal;
+    }
+
     /**
      * Added host mapping support for multi-site hosting
      */


### PR DESCRIPTION
## Summary

Pass optional `signal` (from AbortController) through to node-fetch in `executeRequest`.

## Why

IDLive Doc document-liveness calls run in parallel with MicroBlink in idproofing-api. When MB finishes first, we need to abort the IDLive request immediately (zero extra latency). Without signal support in WTM, the TCP connection stays open until IDLive responds (~6-7s wasted).

## Change

```js
// New: if caller passes { signal: controller.signal }, forward it to node-fetch
if (object.signal) {
    request.signal = object.signal;
}
```

## Backward compatibility

Fully backward-compatible. Existing callers don't pass `signal`, so behavior is unchanged. Only callers that explicitly provide a signal get cancellation behavior.

## Usage (consumer side)

```js
const controller = new AbortController();
const response = await WTM.executeRequest({
  method: 'POST',
  url: endpoint,
  body,
  signal: controller.signal,
  // ...other options
});
// To cancel: controller.abort();
```